### PR TITLE
Fix incorrect exception in sscollectionview  item size for section

### DIFF
--- a/SSToolkit/SSCollectionView.m
+++ b/SSToolkit/SSCollectionView.m
@@ -199,11 +199,14 @@
 
 - (CGSize)_itemSizeForSection:(NSInteger)section {
 	// TODO: Cache this value to elminate lots of method calls
-	if ([_delegate respondsToSelector:@selector(collectionView:itemSizeForSection:)] == NO) {
-		[[NSException exceptionWithName:kSSCollectionViewMissingItemSizeExceptionName reason:kSSCollectionViewMissingItemSizeExceptionReason userInfo:nil] raise];
-		return CGSizeZero;
-	}	
-	return [_delegate collectionView:self itemSizeForSection:section];
+    if (_delegate) {
+        if ([_delegate respondsToSelector:@selector(collectionView:itemSizeForSection:)] == NO) {
+            [[NSException exceptionWithName:kSSCollectionViewMissingItemSizeExceptionName reason:kSSCollectionViewMissingItemSizeExceptionReason userInfo:nil] raise];
+            return CGSizeZero;
+        }	
+        return [_delegate collectionView:self itemSizeForSection:section];
+    }
+    return CGSizeZero;
 }
 
 


### PR DESCRIPTION
An exception is being raised because a check to see if the _delegate responds to collectionView:itemSizeForSection: returns NO will also return NO if the _delegate has been nilled out. This fix checks first to see if there is a delegate and then does the responds  to selector check.
