### PR TITLE
Check delegate and datasource before reloading

### DIFF
--- a/SSToolkit/SSCollectionView.m
+++ b/SSToolkit/SSCollectionView.m
@@ -278,7 +278,7 @@
 - (void)setDataSource:(id<SSCollectionViewDataSource>)dataSource {
 	_dataSource = dataSource;
 	
-	if (_delegate) {
+	if (_delegate && _dataSource) {
 		[self reloadData];
 	}
 }
@@ -287,7 +287,7 @@
 - (void)setDelegate:(id<SSCollectionViewDelegate>)delegate {
 	_delegate = delegate;
 	
-	if (_dataSource) {
+	if (_delegate && _dataSource) {
 		[self reloadData];
 	}
 }


### PR DESCRIPTION
When setting the SSCollectionView dataSource or delegate check that both are set before calling reloadData.

This fixes an issue in which an exception is being raised in SSCollectionView _itemSizeForSection because reloadData is being called when setting the delegate and/or dataSource to nil which causes the _itemSizeForSection method to be called which raises an exception because a nil delegate does not respond to collectionView:itemSizeForSection:.
