### PR TITLE
Added Trimming Methods to NSString category

### DIFF
--- a/SSToolkit/NSString+SSToolkitAdditions.h
+++ b/SSToolkit/NSString+SSToolkitAdditions.h
@@ -31,4 +31,10 @@
 // Base64
 - (NSString *)base64EncodedString;
 
+// Trimming
+- (NSString *)stringByTrimmingLeadingCharactersInSet:(NSCharacterSet *)characterSet;
+- (NSString *)stringByTrimmingLeadingWhitespaceAndNewlineCharacters;
+- (NSString *)stringByTrimmingTrailingCharactersInSet:(NSCharacterSet *)characterSet;
+- (NSString *)stringByTrimmingTrailingWhitespaceAndNewlineCharacters;
+
 @end

--- a/SSToolkit/NSString+SSToolkitAdditions.m
+++ b/SSToolkit/NSString+SSToolkitAdditions.m
@@ -284,4 +284,34 @@ static const char encodingTable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq
     return [[[NSString alloc] initWithBytesNoCopy:characters length:length encoding:NSASCIIStringEncoding freeWhenDone:YES] autorelease];
 }
 
+
+#pragma mark Trimming Methods
+
+- (NSString *)stringByTrimmingLeadingCharactersInSet:(NSCharacterSet *)characterSet {
+    NSRange rangeOfFirstWantedCharacter = [self rangeOfCharacterFromSet:[characterSet invertedSet]];
+    if (rangeOfFirstWantedCharacter.location == NSNotFound) {
+        return @"";
+    }
+    return [self substringFromIndex:rangeOfFirstWantedCharacter.location];
+}
+
+- (NSString *)stringByTrimmingLeadingWhitespaceAndNewlineCharacters {
+    return [self stringByTrimmingLeadingCharactersInSet:
+            [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
+- (NSString *)stringByTrimmingTrailingCharactersInSet:(NSCharacterSet *)characterSet {
+    NSRange rangeOfLastWantedCharacter = [self rangeOfCharacterFromSet:[characterSet invertedSet]
+                                                               options:NSBackwardsSearch];
+    if (rangeOfLastWantedCharacter.location == NSNotFound) {
+        return @"";
+    }
+    return [self substringToIndex:rangeOfLastWantedCharacter.location+1]; // non-inclusive
+}
+
+- (NSString *)stringByTrimmingTrailingWhitespaceAndNewlineCharacters {
+    return [self stringByTrimmingTrailingCharactersInSet:
+            [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
 @end


### PR DESCRIPTION
I wrote these methods for AcaniChat and thought they may be generally useful enough to include in the toolkit.

```
- (NSString *)stringByTrimmingLeadingCharactersInSet:(NSCharacterSet *)characterSet;
- (NSString *)stringByTrimmingLeadingWhitespaceAndNewlineCharacters;
- (NSString *)stringByTrimmingTrailingCharactersInSet:(NSCharacterSet *)characterSet;
- (NSString *)stringByTrimmingTrailingWhitespaceAndNewlineCharacters;
```

I wanted to trim only the trailing whitespace and newline characters of a message before sending it.

Playing around with my iPhone, I noticed that when I texted myself a message with surrounding whitespace and newline characters, the sent message bubble appeared the same, but the received message bubble appeared with the trailing whitespace and newline characters trimmed.

I think this is a bug (which I just reported to Apple) because the sent message should appear exactly as it's received, so I decided to trim the trailing spaces before sending the message & displaying it in the sent bubble.
