### PR TITLE
Preventing divide by zero when itemSize.width + _minimumColumnSpacing > t

### DIFF
--- a/SSToolkit/SSCollectionView.m
+++ b/SSToolkit/SSCollectionView.m
@@ -359,6 +359,10 @@
 	CGSize itemSize = [self _itemSizeForSection:section];
 	CGFloat itemsPerRow = floorf(self.frame.size.width / (itemSize.width + _minimumColumnSpacing));
 	
+	if (itemsPerRow == 0.00) {
+		return 0;
+	}
+
 	NSInteger rows = (NSInteger)ceilf((CGFloat)totalItems / itemsPerRow);
 	return rows;
 }


### PR DESCRIPTION
Preventing divide by zero when itemSize.width + _minimumColumnSpacing > the frame size. Causes a crash on my iPod but not in the simulator.
