### PR TITLE
Make firstObject behave like the documentation says ;)

### DIFF
--- a/SSToolkit/NSArray+SSToolkitAdditions.m
+++ b/SSToolkit/NSArray+SSToolkitAdditions.m
@@ -16,6 +16,10 @@
 @implementation NSArray (SSToolkitAdditions)
 
 - (id)firstObject {
+	if ([self count] == 0) {
+	    return nil;
+	}
+	
 	return [self objectAtIndex:0];
 }
 


### PR DESCRIPTION
Just a small fix to make firstObject work on an empty NSArray without crashing.
