### PR TITLE
Minor tweaks to improve MD5 / SHA1 performance

### DIFF
--- a/SSToolkit/NSData+SSToolkitAdditions.h
+++ b/SSToolkit/NSData+SSToolkitAdditions.h
@@ -29,6 +29,13 @@
  */
 - (NSString *)SHA1Sum;
 
+/**
+ Returns a string of the SHA256 sum of the receiver.
+ 
+ @return The string of the SHA256 sum of the receiver.
+ */
+- (NSString *)SHA256Sum;
+
 ///-----------------------------------
 /// @name Base64 Encoding and Decoding
 ///-----------------------------------

--- a/SSToolkit/NSData+SSToolkitAdditions.m
+++ b/SSToolkit/NSData+SSToolkitAdditions.m
@@ -31,24 +31,41 @@ static const short _base64DecodingTable[256] = {
 
 @implementation NSData (SSToolkitAdditions)
 
+
 - (NSString *)MD5Sum {
-	unsigned char digest[CC_MD5_DIGEST_LENGTH], i;
+	unsigned char digest[CC_MD5_DIGEST_LENGTH];
 	CC_MD5(self.bytes, self.length, digest);
-	NSMutableString *ms = [NSMutableString string];
-	for (i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
-		[ms appendFormat: @"%02x", (int)(digest[i])];
+	char digestHexString[(CC_MD5_DIGEST_LENGTH * 2)];
+	for (NSInteger i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
+		int high = (digest[i] >> 4) & 0xf, low = (digest[i] >> 0) & 0xf;
+		digestHexString[(i * 2) + 0] = (high < 0xa) ? '0' + high : 'a' + (high - 10);
+		digestHexString[(i * 2) + 1] = (low  < 0xa) ? '0' + low  : 'a' + (low  - 10);
 	}
-	return [[ms copy] autorelease];
+	return([[[NSString alloc] initWithBytes:digestHexString length:(CC_MD5_DIGEST_LENGTH * 2) encoding:NSMacOSRomanStringEncoding] autorelease]);
 }
 
 - (NSString *)SHA1Sum {
-	NSMutableString *output = [NSMutableString stringWithCapacity:CC_SHA1_DIGEST_LENGTH * 2];
 	uint8_t digest[CC_SHA1_DIGEST_LENGTH];
 	CC_SHA1(self.bytes, self.length, digest);
+	char digestHexString[(CC_SHA1_DIGEST_LENGTH * 2)];
 	for (NSInteger i = 0; i < CC_SHA1_DIGEST_LENGTH; i++) {
-		[output appendFormat:@"%02x", digest[i]];
+		int high = (digest[i] >> 4) & 0xf, low = (digest[i] >> 0) & 0xf;
+		digestHexString[(i * 2) + 0] = (high < 0xa) ? '0' + high : 'a' + (high - 10);
+		digestHexString[(i * 2) + 1] = (low  < 0xa) ? '0' + low  : 'a' + (low  - 10);
 	}
-	return output;
+	return([[[NSString alloc] initWithBytes:digestHexString length:(CC_SHA1_DIGEST_LENGTH * 2) encoding:NSMacOSRomanStringEncoding] autorelease]);
+}
+
+- (NSString *)SHA256Sum {
+	uint8_t digest[CC_SHA256_DIGEST_LENGTH];
+	CC_SHA1(self.bytes, self.length, digest);
+	char digestHexString[(CC_SHA256_DIGEST_LENGTH * 2)];
+	for (NSInteger i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+		int high = (digest[i] >> 4) & 0xf, low = (digest[i] >> 0) & 0xf;
+		digestHexString[(i * 2) + 0] = (high < 0xa) ? '0' + high : 'a' + (high - 10);
+		digestHexString[(i * 2) + 1] = (low  < 0xa) ? '0' + low  : 'a' + (low  - 10);
+	}
+	return([[[NSString alloc] initWithBytes:digestHexString length:(CC_SHA256_DIGEST_LENGTH * 2) encoding:NSMacOSRomanStringEncoding] autorelease]);
 }
 
 


### PR DESCRIPTION
Create the hex string in a much more efficient way.  Also add SHA256.

As a possible feature addition, you might want to think about adding something like:

``` objective-c
- (NSString *)MD5String;
- (NSData *)MD5Data;
```

The `MD5String` method is just `MD5Sum` renamed.  `MD5Data` returns a `NSData` object created with something like `[NSData dataWithBytes:digest length:CC...]`.  Occasionally you want the hash in raw bytes, and with just a hex string, you have to add a bunch of extra steps to convert it back to raw bytes.  And I'm clearly handwaving the public API changes that this implies.  :)
