### PR TITLE
Fixed memory leak in SSCollectionViewController

### DIFF
--- a/SSToolkit/SSCollectionViewController.m
+++ b/SSToolkit/SSCollectionViewController.m
@@ -70,10 +70,13 @@
 #pragma mark - Private
 
 - (void)_initialize {
-	_collectionView = [[SSCollectionView alloc] initWithFrame:CGRectZero];
-	_collectionView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-	_collectionView.dataSource = self;
-	_collectionView.delegate = self;
+    if ( ! _collectionView )
+    {
+        _collectionView = [[SSCollectionView alloc] initWithFrame:CGRectZero];
+        _collectionView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        _collectionView.dataSource = self;
+        _collectionView.delegate = self;
+    }
 }
 
 


### PR DESCRIPTION
SSCollectionViewController leaked 1 SSCollectionView object immediately
after initialization.

Modified behavior to only create a SSCollectionView if it doesn't exist.

This could be improved because the real problem is with _initialize being called twice.
