### PR TITLE
SSWebView's scrollView should be determined at run-time instead of compile-time

### DIFF
--- a/SSToolkit/SSWebView.m
+++ b/SSToolkit/SSWebView.m
@@ -322,16 +322,17 @@
 
 
 - (UIScrollView *)scrollView {
-#ifndef __IPHONE_5_0
-	for (UIView *view in [_webView subviews]) {
-		if ([view isKindOfClass:[UIScrollView class]]) {
-			return (UIScrollView *)view;
+	if (([[[UIDevice currentDevice] systemVersion] compare:@"5.0"] == NSOrderedAscending)) {
+		for (UIView *view in [_webView subviews]) {
+			if ([view isKindOfClass:[UIScrollView class]]) {
+				return (UIScrollView *)view;
+			}
 		}
+		return nil;
 	}
-	return nil;
-#else
-	return _webView.scrollView;
-#endif
+	else {
+		return _webView.scrollView;
+	}
 }
 
 


### PR DESCRIPTION
There is an error occurring when building with iOS5 SDK (Xcode 4.2) and 
setting iOS Deployment Target to iOS4.0.

Please check it! 
