### PR TITLE
dateFromISO8601String causes SIGABRT with UTC time

### DIFF
--- a/SSToolkit/NSDate+SSToolkitAdditions.m
+++ b/SSToolkit/NSDate+SSToolkitAdditions.m
@@ -18,7 +18,7 @@
 	}
 
 	const char *str = [iso8601 cStringUsingEncoding:NSUTF8StringEncoding];
-	char newStr[24];
+	char newStr[25];
 
 	struct tm tm;
 	size_t len = strlen(str);
@@ -29,7 +29,7 @@
 	// UTC
 	if (len == 20 && str[len - 1] == 'Z') {
 		strncpy(newStr, str, len - 1);
-		strncpy(newStr + len - 1, "+0000\0", 6);
+		strncpy(newStr + len - 1, "+0000", 5);
 	}
 
 	// Timezone
@@ -43,6 +43,9 @@
 		strncpy(newStr, str, len > 24 ? 24 : len);
 	}
 
+  // Add null terminator
+  newStr[sizeof(newStr) - 1] = 0;
+  
 	if (strptime(newStr, "%FT%T%z", &tm) == NULL) {
 		return nil;
 	}


### PR DESCRIPTION
Fixed possible SIGABRT in `dateFromISO8601String` due to `strncpy` writing past the end of the stack buffer. When `dateFromISO8601String` parses an ISO 8601 string with UTC time (e.g., `2012-03-10T21:49:45Z`), a SIGABRT may occur. This is because `newStr` is allocated with size 24, but 25 bytes are written if the time is a UTC time. 

My solution was to increase the size of `newStr` and make the last character `null` before parsing `newStr` with `strptime`, since I believe `strncpy` will not null-terminate copied strings. 
