### PR TITLE
Replace arc4random() with arc4random_uniform() to improve randomness

### DIFF
--- a/SSToolkit/NSArray+SSToolkitAdditions.m
+++ b/SSToolkit/NSArray+SSToolkitAdditions.m
@@ -25,7 +25,7 @@
 
 
 - (id)randomObject {
-	return [self objectAtIndex:arc4random() % [self count]];
+	return [self objectAtIndex:arc4random_uniform([self count])];
 }
 
 


### PR DESCRIPTION
Using arc4random() % [self count] to choose an object will generate biased results when the array length is not a power of 2. Switching to arc4random_uniform() fixes this.
