### PR TITLE
exception when SSCollectionView is loaded from nib

### DIFF
--- a/SSToolkit/SSCollectionView.m
+++ b/SSToolkit/SSCollectionView.m
@@ -449,7 +449,7 @@ static NSString *kSSCollectionViewSectionItemSizeKey = @"SSCollectionViewSection
 #pragma mark - Reloading the Collection View
 
 - (void)reloadData {
-	if (![self superview]) {
+	if (![self superview] || !_delegate || !_dataSource) {
 		return;
 	}
 	
@@ -497,18 +497,14 @@ static NSString *kSSCollectionViewSectionItemSizeKey = @"SSCollectionViewSection
 - (void)setDataSource:(id<SSCollectionViewDataSource>)dataSource {
 	_dataSource = dataSource;
 	
-	if (_delegate && _dataSource) {
-		[self reloadData];
-	}
+	[self reloadData];
 }
 
 
 - (void)setDelegate:(id<SSCollectionViewDelegate>)delegate {
 	_delegate = delegate;
 	
-	if (_delegate && _dataSource) {
-		[self reloadData];
-	}
+	[self reloadData];
 }
 
 


### PR DESCRIPTION
When delegates are yet nil setFrame is called, causing SSCollectionViewInvalidItemSizeExceptionName to be thrown.
