### PR TITLE
Added convient way to completely reset SSRateLimit

### DIFF
--- a/SSToolkit/SSRateLimit.h
+++ b/SSToolkit/SSRateLimit.h
@@ -38,4 +38,11 @@
  */
 + (void)resetLimitForName:(NSString *)name;
 
+/**
+ Resets the time for all of the names.
+ 
+ The next time a block with any name is passed to `executeBlock:name:limit:` it will be executed.
+ */
++ (void)resetAllLimits;
+
 @end

--- a/SSToolkit/SSRateLimit.m
+++ b/SSToolkit/SSRateLimit.m
@@ -42,6 +42,11 @@
 }
 
 
++ (void)resetAllLimits {
+  [[self _dictionary] removeAllObjects];
+}
+
+
 #pragma mark - Private
 
 + (NSMutableDictionary *)_dictionary {


### PR DESCRIPTION
This is a convenient way to reset all of the rate limits at once. An example use case is that of a user logging out and another one logging in—the new user should get a "clean slate" and not be bound by any previous rate limits.
