### PR TITLE
Changed SSCollectionViewDelegate selection methods

### DIFF
--- a/SSToolkit/SSCollectionView.h
+++ b/SSToolkit/SSCollectionView.h
@@ -583,7 +583,7 @@ typedef enum {
  @see collectionView:didSelectItemAtIndexPath:
  @see collectionView:willDeselectItemAtIndexPath:
  */
-- (void)collectionView:(SSCollectionView *)aCollectionView willSelectItemAtIndexPath:(NSIndexPath *)indexPath;
+- (NSIndexPath *)collectionView:(SSCollectionView *)aCollectionView willSelectItemAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
  Tells the delegate that the specified item is now selected.
@@ -615,7 +615,7 @@ typedef enum {
  @see collectionView:didDeselectItemAtIndexPath:
  @see collectionView:willSelectItemAtIndexPath:
  */
-- (void)collectionView:(SSCollectionView *)aCollectionView willDeselectItemAtIndexPath:(NSIndexPath *)indexPath;
+- (NSIndexPath *)collectionView:(SSCollectionView *)aCollectionView willDeselectItemAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
  Tells the delegate that the specified item is now deselected.

--- a/SSToolkit/SSCollectionView.m
+++ b/SSToolkit/SSCollectionView.m
@@ -262,42 +262,46 @@ static NSString *kSSCollectionViewSectionItemSizeKey = @"SSCollectionViewSection
 - (void)selectItemAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated scrollPosition:(SSCollectionViewScrollPosition)scrollPosition {
 	// Notify delegate that it will select
 	if ([self.delegate respondsToSelector:@selector(collectionView:willSelectItemAtIndexPath:)]) {
-		[self.delegate collectionView:self willSelectItemAtIndexPath:indexPath];
+		indexPath = [self.delegate collectionView:self willSelectItemAtIndexPath:indexPath];
 	}
 	
-	// Select
-	SSCollectionViewItem *item = [self itemForIndexPath:indexPath];
-	[item setHighlighted:NO animated:NO];
-	[item setSelected:YES animated:YES];
-	
-	// Scroll to position
-	if (scrollPosition == SSCollectionViewScrollPositionTop || scrollPosition == SSCollectionViewScrollPositionMiddle ||
-		scrollPosition == SSCollectionViewScrollPositionBottom) {
-		[self scrollToItemAtIndexPath:indexPath atScrollPosition:scrollPosition animated:animated];
-	}
-	
-	// Notify delegate that it did selection
-	if ([self.delegate respondsToSelector:@selector(collectionView:didSelectItemAtIndexPath:)]) {
-		[self.delegate collectionView:self didSelectItemAtIndexPath:indexPath];
-	}
+	// Select, if delegate hasn't set the indexPath to nil
+    if (indexPath) {
+        SSCollectionViewItem *item = [self itemForIndexPath:indexPath];
+        [item setHighlighted:NO animated:NO];
+        [item setSelected:YES animated:YES];
+        
+        // Scroll to position
+        if (scrollPosition == SSCollectionViewScrollPositionTop || scrollPosition == SSCollectionViewScrollPositionMiddle ||
+            scrollPosition == SSCollectionViewScrollPositionBottom) {
+            [self scrollToItemAtIndexPath:indexPath atScrollPosition:scrollPosition animated:animated];
+        }
+        
+        // Notify delegate that it did selection
+        if ([self.delegate respondsToSelector:@selector(collectionView:didSelectItemAtIndexPath:)]) {
+            [self.delegate collectionView:self didSelectItemAtIndexPath:indexPath];
+        }
+    }
 }
 
 
 - (void)deselectItemAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated {
 	// Notify delegate that it will deselect
 	if ([self.delegate respondsToSelector:@selector(collectionView:willDeselectItemAtIndexPath:)]) {
-		[self.delegate collectionView:self willDeselectItemAtIndexPath:indexPath];
+		indexPath = [self.delegate collectionView:self willDeselectItemAtIndexPath:indexPath];
 	}
 	
-	// Deselect
-	SSCollectionViewItem *item = [self itemForIndexPath:indexPath];
-	[item setHighlighted:NO animated:NO];
-	[item setSelected:NO animated:YES];
-	
-	// Notify delegate that it did deselection
-	if ([self.delegate respondsToSelector:@selector(collectionView:didDeselectItemAtIndexPath:)]) {
-		[self.delegate collectionView:self didDeselectItemAtIndexPath:indexPath];
-	}
+	// Deselect, if delegate hasn't set the indexPath to nil
+    if (indexPath) {
+        SSCollectionViewItem *item = [self itemForIndexPath:indexPath];
+        [item setHighlighted:NO animated:NO];
+        [item setSelected:NO animated:YES];
+        
+        // Notify delegate that it did deselection
+        if ([self.delegate respondsToSelector:@selector(collectionView:didDeselectItemAtIndexPath:)]) {
+            [self.delegate collectionView:self didDeselectItemAtIndexPath:indexPath];
+        }
+    }
 }
 
 


### PR DESCRIPTION
changed SSCollectionViewDelegate selection methods 
    collectionView:willSelectItemAtIndexPath: 
    collectionView:willDeselectItemAtIndexPath: 
to return an NSIndexPath object as per SSToolkit documentation and to match the style of the UITableViewDelegate.

Also Changed methods:
    selectItemAtIndexPath:animated:scrollPosition:
    deselectItemAtIndexPath:animated:
to avoid doing anything if the delegate returns nil for the indexPath
