### PR TITLE
Problems with SSCollectionView

### DIFF
--- a/SSToolkit/SSCollectionView.m
+++ b/SSToolkit/SSCollectionView.m
@@ -453,7 +453,7 @@ static NSString *kSSCollectionViewSectionItemSizeKey = @"SSCollectionViewSection
 #pragma mark - Reloading the Collection View
 
 - (void)reloadData {
-	if (![self superview]) {
+	if (![self superview] || !_dataSource || !_delegate) {
 		return;
 	}
 	


### PR DESCRIPTION
reloadData should not be executed if no datasource or delegate is set.
