### PR TITLE
Update SSToolkit/NSMutableArray+SSToolkitAdditions.m

### DIFF
--- a/SSToolkit/NSMutableArray+SSToolkitAdditions.m
+++ b/SSToolkit/NSMutableArray+SSToolkitAdditions.m
@@ -4,7 +4,7 @@
 
 - (void)shuffle
 {
-    for (NSUInteger i = [self count] - 1; i > 0; i--) {
+    for (NSInteger i = [self count] - 1; i > 0; i--) {
         [self exchangeObjectAtIndex:arc4random_uniform(i + 1)
                   withObjectAtIndex:i];
     }


### PR DESCRIPTION
Declaring i as an NSUInteger causes an exception when the NSMutableArray is empty. Indeed 0 - 1 == maximum integer value when the given integer is unsigned.
