### PR TITLE
Added SSCategories import to SSToolkit.h

### DIFF
--- a/SSToolkit/SSToolkit.h
+++ b/SSToolkit/SSToolkit.h
@@ -39,3 +39,6 @@
 #import <SSToolkit/SSConcurrentOperation.h>
 #import <SSToolkit/SSDrawingUtilities.h>
 #import <SSToolkit/SSRateLimit.h>
+
+// Categories
+#import <SSToolkit/SSCategories.h>


### PR DESCRIPTION
I end up using `SSToolkit` a lot, but not always for its controls. 

The categories included are really really useful. So useful in fact, that I think they should be included in the default import. That way, new users aren't confused when they follow the install instructions and then can't use `dictionaryWithFormEncodedString` or `deepMutableCopy`.

For your enjoyment, the first Google Images search for "SSCategories":
![http://www.uniplot.de/documents/en/_images/ToolsMoreOptions-en.png](http://www.uniplot.de/documents/en/_images/ToolsMoreOptions-en.png)
