### PR TITLE
Safe returning nil on randomObject on NSArray category

### DIFF
--- a/SSToolkit/NSArray+SSToolkitAdditions.m
+++ b/SSToolkit/NSArray+SSToolkitAdditions.m
@@ -26,6 +26,10 @@
 
 
 - (id)randomObject {
+	if ([self count] == 0) {
+	    return nil;
+	}
+	
 	return [self objectAtIndex:arc4random_uniform([self count])];
 }
 


### PR DESCRIPTION
Implemented the same way it's implemented on firstObject.
