### PR TITLE
valueForKey: → objectForKey:

### DIFF
--- a/SSToolkit/NSDictionary+SSToolkitAdditions.m
+++ b/SSToolkit/NSDictionary+SSToolkitAdditions.m
@@ -79,11 +79,11 @@
 
 
 - (id)safeObjectForKey:(id)key {
-	id value = [self valueForKey:key];
-	if (value == [NSNull null]) {
+	id object = [self objectForKey:key];
+	if (object == [NSNull null]) {
 		return nil;
 	}
-	return value;
+	return object;
 }
 
 @end


### PR DESCRIPTION
Whenever I see `valueForKey` being called on an `NSDictionary`, I get a little queasy. Why use `NSKeyValueCoding`, when you don't need to?

:beer:
