### PR TITLE
fixed deprecated call in iOS 7

### DIFF
--- a/SSToolkit/SSTextView.m
+++ b/SSToolkit/SSTextView.m
@@ -107,11 +107,23 @@
 
 		// Draw the text
 		[_placeholderTextColor set];
+		if ([_placeholder respondsToSelector:@selector(drawInRect:withAttributes:)])
+        {
+            NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+            paragraphStyle.lineBreakMode = NSLineBreakByTruncatingTail;
+            paragraphStyle.alignment = self.textAlignment;
+            NSDictionary *attributes = @{NSFontAttributeName : self.font,
+                                         NSParagraphStyleAttributeName : paragraphStyle};
+            [_placeholder drawInRect:rect withAttributes:attributes];
+        }
+        else
+        {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0
-		[_placeholder drawInRect:rect withFont:self.font lineBreakMode:NSLineBreakByTruncatingTail alignment:self.textAlignment];
+            [_placeholder drawInRect:rect withFont:self.font lineBreakMode:NSLineBreakByTruncatingTail alignment:self.textAlignment];
 #else
-		[_placeholder drawInRect:rect withFont:self.font lineBreakMode:UILineBreakModeTailTruncation alignment:self.textAlignment];
+            [_placeholder drawInRect:rect withFont:self.font lineBreakMode:UILineBreakModeTailTruncation alignment:self.textAlignment];
 #endif
+        }
 	}
 }
 


### PR DESCRIPTION
SSTextView in drawRect: calls drawInRect:withFont:lineBreakMode:alignment: which is deprecated in iOS 7 and needs to be switched to drawInRect:withAttributes:.
