### PR TITLE
Fixed placeholder position for SSTextField on iOS 7

### DIFF
--- a/SSToolkit/SSTextField.m
+++ b/SSToolkit/SSTextField.m
@@ -74,11 +74,19 @@
 	}
 	
     [_placeholderTextColor setFill];
+    
+    //check iOS version is >= 7.0
+    if (([[[UIDevice currentDevice] systemVersion] compare:@"7.0" options:NSNumericSearch] != NSOrderedAscending)) {
+        rect =  CGRectInset(rect, 0, (rect.size.height - self.font.lineHeight) / 2.0);
+        [self.placeholder drawInRect:rect withAttributes:@{NSFontAttributeName:self.font, UITextAttributeTextColor:_placeholderTextColor}];
+    }
+    else {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0
-    [self.placeholder drawInRect:rect withFont:self.font lineBreakMode:NSLineBreakByTruncatingTail alignment:self.textAlignment];
+        [self.placeholder drawInRect:rect withFont:self.font lineBreakMode:NSLineBreakByTruncatingTail alignment:self.textAlignment];
 #else
-    [self.placeholder drawInRect:rect withFont:self.font lineBreakMode:UILineBreakModeTailTruncation alignment:self.textAlignment];
+        [self.placeholder drawInRect:rect withFont:self.font lineBreakMode:UILineBreakModeTailTruncation alignment:self.textAlignment];
 #endif
+    }
 }
 
 


### PR DESCRIPTION
In iOS7 all methods like like drawInRect:withFont: are deprecated and give the wrong text appearance (always aligned to top). Rect should be adopted for vertically centering text. 

Example of incorrect placeholder position:
![Placeholder](http://habrastorage.org/storage3/3e3/aa2/b48/3e3aa2b482d57c3c46c216adbd5b83cc.jpg)

Added rect adjustments for iOS 7 as adviced [here](http://stackoverflow.com/a/3396065/2797141):

``` objective-c
CGRectInset(rect, 0, (rect.size.height - self.font.lineHeight) / 2.0);
```
